### PR TITLE
Fix: Resolve PHPMailer class not found error

### DIFF
--- a/config.php
+++ b/config.php
@@ -80,4 +80,12 @@ define('SMTP_PASSWORD', 'your_smtp_password'); // Your SMTP password
 define('SMTP_PORT', 465);                         // SMTP port (e.g., 465 for SSL, 587 for TLS)
 define('SMTP_SECURE', 'ssl');                   // SMTP encryption type ('ssl' or 'tls')
 
+// Include PHPMailer classes
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+require __DIR__ . '/vendor/phpmailer/phpmailer/src/Exception.php';
+require __DIR__ . '/vendor/phpmailer/phpmailer/src/PHPMailer.php';
+require __DIR__ . '/vendor/phpmailer/phpmailer/src/SMTP.php';
+
 ?>

--- a/utils/functions.php
+++ b/utils/functions.php
@@ -113,15 +113,10 @@ function format_time_display($time_str, $format = "h:i A") {
 
 // Add more utility functions as needed, e.g., for pagination, email sending, etc.
 
+// PHPMailer classes are now included in config.php, so they are available globally.
+// We just need to use the namespace.
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
-
-// Since we are not using Composer's autoloader, we need to require the files manually.
-// The paths must be relative to this file's location (`utils/`).
-require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/Exception.php';
-require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/PHPMailer.php';
-require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/SMTP.php';
-
 
 // Function to send email using PHPMailer
 function send_email($to, $subject, $html_message, $from_email, $from_name) {


### PR DESCRIPTION
Centralizes the inclusion of PHPMailer class files (`Exception.php`, `PHPMailer.php`, and `SMTP.php`) into `config.php`. This ensures that all necessary classes are loaded globally and in the correct order, preventing `Fatal error: Class not found` issues.

Removed the redundant `require_once` statements from `utils/functions.php` to avoid duplication.