### PR TITLE
Fix: Implement manual autoloader for PHPMailer

### DIFF
--- a/config.php
+++ b/config.php
@@ -80,12 +80,7 @@ define('SMTP_PASSWORD', 'your_smtp_password'); // Your SMTP password
 define('SMTP_PORT', 465);                         // SMTP port (e.g., 465 for SSL, 587 for TLS)
 define('SMTP_SECURE', 'ssl');                   // SMTP encryption type ('ssl' or 'tls')
 
-// Include PHPMailer classes
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
-require __DIR__ . '/vendor/phpmailer/phpmailer/src/Exception.php';
-require __DIR__ . '/vendor/phpmailer/phpmailer/src/PHPMailer.php';
-require __DIR__ . '/vendor/phpmailer/phpmailer/src/SMTP.php';
+// Include PHPMailer autoloader
+require_once __DIR__ . '/vendor/autoload.php';
 
 ?>

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,0 +1,30 @@
+<?php
+// vendor/autoload.php
+
+spl_autoload_register(function ($class) {
+    // Project-specific namespace prefix
+    $prefix = 'PHPMailer\\PHPMailer\\';
+
+    // Base directory for the namespace prefix
+    $base_dir = __DIR__ . '/phpmailer/phpmailer/src/';
+
+    // Does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        // No, move to the next registered autoloader
+        return;
+    }
+
+    // Get the relative class name
+    $relative_class = substr($class, $len);
+
+    // Replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    // If the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
Replaces individual `require_once` statements for PHPMailer classes with a manual autoloader (`vendor/autoload.php`) to ensure classes are loaded correctly and resolve 'Class not found' fatal errors.

The `config.php` file now includes this single autoloader, which handles the loading of PHPMailer, SMTP, and Exception classes on demand.