### PR TITLE
Fix: Prevent duplicate bookings on form resubmission

### DIFF
--- a/book_appointment.php
+++ b/book_appointment.php
@@ -9,6 +9,17 @@ $user_id = null;
 $errors = [];
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // CSRF Token Validation
+    if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        // Token mismatch, handle the error (e.g., redirect or show an error message)
+        $_SESSION['error_message'] = "Invalid form submission. Please try again.";
+        redirect(BASE_URL . "/bookinapp.php");
+        exit;
+    }
+
+    // Invalidate the token to prevent reuse
+    unset($_SESSION['csrf_token']);
+
     // --- Form Data Collection and Basic Sanitization ---
     $service_id = isset($_POST['service_id']) ? (int)$_POST['service_id'] : null;
     $booking_date = isset($_POST['booking_date']) ? sanitize_input($_POST['booking_date']) : null;

--- a/bookinapp.php
+++ b/bookinapp.php
@@ -32,6 +32,12 @@
     unset($_SESSION['form_data'], $_SESSION['form_errors']);
 
     $selected_service_id = $form_data['service_id'] ?? ($_GET['service_id'] ?? '');
+
+    // Generate CSRF token
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    $csrf_token = $_SESSION['csrf_token'];
     ?>
     <div
       class="relative flex size-full min-h-screen flex-col bg-[#232010] dark group/design-root overflow-x-hidden"
@@ -73,6 +79,7 @@
             <?php echo display_flash_message(); ?>
 
             <form id="bookingForm" action="<?php echo BASE_URL . '/book_appointment.php'; ?>" method="POST">
+                <input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>">
                 <div class="form-group px-4 py-3">
                     <label for="service_id" class="block text-[#cdc28e] text-sm font-medium mb-1">Service</label>
                     <select name="service_id" id="service_id" required


### PR DESCRIPTION
Implements a CSRF token-based mechanism to prevent duplicate booking creation when the booking form is resubmitted (e.g., by using the browser's back button and refreshing).

- A unique token is generated and stored in the session when the booking form page (`bookinapp.php`) is loaded.
- The token is included as a hidden field in the form.
- The processing script (`book_appointment.php`) now validates this token.
- Upon successful validation, the token is immediately invalidated to ensure it can only be used once.